### PR TITLE
Tune bsc witness for public archive RPCs

### DIFF
--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -1,8 +1,8 @@
 chain: "bsc"
 grpcPort: 9286
 grpcProxyPort: 9287
-interval: 30s
-batchSize: 100
+interval: 10s
+batchSize: 10
 database:
   uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
@@ -10,7 +10,7 @@ cashiers:
   - id: "bsc-to-iotex-payload"
     withPayload: true
     relayerURL: ":7201"
-    startBlockHeight: 99500000
+    startBlockHeight: 99705816
     cashierContractAddress: "0x78de1E0b76523Ac6E190F89FFC46571346940204"
     tokenSafeContractAddress: "0xfbe9a4138afdf1fa639a8c2818a0c4513fc4ce4b"
     validatorContractAddress: "0x915241176a644A29F46F5F4F8Bd49309e461a9bD"


### PR DESCRIPTION
## Summary
- `interval` 30s -> 10s and `batchSize` 100 -> 10 in `witness-config-bsc-payload.yaml` so the bsc-payload witness works with public BSC archive RPCs that cap `eth_getLogs` at 10 blocks (e.g. `bsc-mainnet.public.blastapi.io`). 10s keeps pace with BSC 1.5s block time given the 10-block batch.
- `startBlockHeight` 99500000 -> 99705816 (current BSC tip) so a fresh witness starts at tip instead of replaying 200k blocks of history that free archive endpoints rate-limit on.

## Test plan
- [ ] Restart `bsc-payload-witness` with the new config and confirm logs show successful 10-block transfer pulls and no "History has been pruned" errors.
- [ ] Confirm the witness keeps pace with chain tip (lag stays bounded, not growing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)