### PR TITLE
enable BSC and Polygon token pairs

### DIFF
--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -16,18 +16,24 @@ cashiers:
     validatorContractAddress: "0x915241176a644A29F46F5F4F8Bd49309e461a9bD"
     transferTableName: "bsc_transfers"
     tokenPairs:
-#       - token1: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
-#         token2: "io1jlnvfzr8lhper2xla8gknmxsqhgajq5ravu4wr"
+      # WBNB
+      - token1: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+        token2: "io1jlnvfzr8lhper2xla8gknmxsqhgajq5ravu4wr"
+      # BUSD
 #       - token1: "0xe9e7cea3dedca5984780bafc599bd69add087d56"
 #         token2: "io1sj4uk2pjhesxxsd9qy52avwmgw4qzazfrypm04"
-#       - token1: "0x810ee35443639348adbbc467b33310d2ab43c168"
-#         token2: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
+      # CYC
+      - token1: "0x810ee35443639348adbbc467b33310d2ab43c168"
+        token2: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
+      # CIOTX
 #       - token1: "0x2aaF50869739e317AB80A57Bf87cAA35F5b60598"
 #         token2: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
-#       - token1: "0x55d398326f99059ff775485246999027b3197955"
-#         token2: "io1gtyj2h272ghg8vtw5ydrhgzv95a0egre4zemtf"
-#       - token1: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
-#         token2: "io1qde5ded9wg540tpv4dkwhrr5lsvva2ga3hf6ry"
+      # BSC-USD
+      - token1: "0x55d398326f99059ff775485246999027b3197955"
+        token2: "io1gtyj2h272ghg8vtw5ydrhgzv95a0egre4zemtf"
+      # USDC
+      - token1: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
+        token2: "io1qde5ded9wg540tpv4dkwhrr5lsvva2ga3hf6ry"
 #       - token1: "0x7e544f2fEDDc69b1cB12555779c824CFe100ee34"
 #         token2: "io1p00c9unkxz0zal2fglhguz3y3vnjd6xlx24h8m"
 #       - token1: "0x049Dd7532148826CdE956c7B45fec8c30b514052"

--- a/witness-config-ethereum-payload.yaml
+++ b/witness-config-ethereum-payload.yaml
@@ -53,8 +53,8 @@ cashiers:
       - token2: "io1cxfj43hs44nqhc6pkhycpezd7vdrpafgxnnzdt"
         token1: "0xb0Ed1F44833C6b2Afa39a6a85ff62C8ad96F5275"
       # CIOTX
-      - token2: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
-        token1: "0x9f90b457dea25ef802e38d470dda7343691d8fe1"
+#      - token2: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
+#        token1: "0x9f90b457dea25ef802e38d470dda7343691d8fe1"
       # CCCS
       - token2: "io1daejpenv38639dw8xplp7c9zr4ff0c9p9kfx3g"
         token1: "0xf79deaBc1406a3AD07c70877fBaEb90777B77E68"

--- a/witness-config-iotex-payload.yaml
+++ b/witness-config-iotex-payload.yaml
@@ -100,24 +100,24 @@ cashiers:
     startBlockHeight: 48300000
     transferTableName: "iotex_to_bsc_transfers"
     tokenPairs:
-#       # WBNB
-#       - token1: "io1jlnvfzr8lhper2xla8gknmxsqhgajq5ravu4wr"
-#         token2: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
-#       # BUSD
+      # WBNB
+      - token1: "io1jlnvfzr8lhper2xla8gknmxsqhgajq5ravu4wr"
+        token2: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+      # BUSD
 #       - token1: "io1sj4uk2pjhesxxsd9qy52avwmgw4qzazfrypm04"
 #         token2: "0xe9e7cea3dedca5984780bafc599bd69add087d56"
-#       # CYC
-#       - token1: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
-#         token2: "0x810ee35443639348adbbc467b33310d2ab43c168"
-#       # CIOTX
+      # CYC
+      - token1: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
+        token2: "0x810ee35443639348adbbc467b33310d2ab43c168"
+      # CIOTX
 #       - token1: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
 #         token2: "0x2aaF50869739e317AB80A57Bf87cAA35F5b60598"
-#       # BSC-USD
-#       - token1: "io1gtyj2h272ghg8vtw5ydrhgzv95a0egre4zemtf"
-#         token2: "0x55d398326f99059ff775485246999027b3197955"
-#       # USDC
-#       - token1: "io1qde5ded9wg540tpv4dkwhrr5lsvva2ga3hf6ry"
-#         token2: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
+      # BSC-USD
+      - token1: "io1gtyj2h272ghg8vtw5ydrhgzv95a0egre4zemtf"
+        token2: "0x55d398326f99059ff775485246999027b3197955"
+      # USDC
+      - token1: "io1qde5ded9wg540tpv4dkwhrr5lsvva2ga3hf6ry"
+        token2: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
 #       # CFOR
 #       - token1: "io1p00c9unkxz0zal2fglhguz3y3vnjd6xlx24h8m"
 #         token2: "0x7e544f2fEDDc69b1cB12555779c824CFe100ee34"
@@ -142,73 +142,73 @@ cashiers:
 #       # NB
 #       - token1: "io130c604xy86n3l0c5s5yx4a4lzklslh6ptq0m94"
 #         token2: "0xD0781be7335ec2C820bD3F9687dDe809892d985e"
-#   - id: "iotex-to-matic-payload"
-#     withPayload: true
-#     relayerURL: ":7204"
-#     cashierContractAddress: "0x8114746E4308a4d3Ff2a74B66414fF35657Fa0E2"
-#     tokenSafeContractAddress: "0xc4A29a94f12be03033daa4e6Ce9b9678c26275a2"
-#     previousCashierContractAddress: "0x124B468860ac994ef28D11643d16e88dd4F26085"
-#     validatorContractAddress: "0x87E2D48De6CC2029fFc1a915462e4Aa597890cd6"
-#     startBlockHeight: 32723537
-#     transferTableName: "iotex_to_matic_transfers"
-#     tokenPairs:
-#       # WMATIC
-#       - token1: "io13envp44hps9j85ulfvs6r6k99wagaky60pzl2c"
-#         token2: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
-#       # WETH
-#       - token1: "io1v5m9d7zrs852xkdzdresqf3phwc5cchc5crylc"
-#         token2: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
-#       # WBTC
-#       - token1: "io10u9dv0ys93nmr7smzyptpkhlhzylt4wtqzrvld"
-#         token2: "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
-#       # DAI
-#       - token1: "io1v25anp7t7nz954gdam2m27eqp4arr93jly4maa"
-#         token2: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
-#       # USDT
-#       - token1: "io18ndhcj88pwz5a5h68yhzz6r4q8vykwhugq45ns"
-#         token2: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
-#       # USDC
-#       - token1: "io1cpx682vazuf4s4amjd7jlwejr5akc65plgmdru"
-#         token2: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
-#       # SUSHI
-#       - token1: "io1990thrrc9cvxhjmsmx5pysznqs734h6uhxfxkq"
-#         token2: "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a"
-#       # QUICK
-#       - token1: "io1u346nz58mj5cjuj7ng3cn96upwam37v9axtju2"
-#         token2: "0x831753DD7087CaC61aB5644b308642cc1c33Dc13"
-#       # AAVE
-#       - token1: "io14tw8gyn3p8v5fcmvh4c0w8797ryjrlrvnsr6zf"
-#         token2: "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
-#       # CYC
-#       - token1: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
-#         token2: "0xcFb54a6D2dA14ABeCD231174FC5735B4436965D8"
-#       # CIOTX
+  - id: "iotex-to-matic-payload"
+    withPayload: true
+    relayerURL: ":7204"
+    cashierContractAddress: "0x8114746E4308a4d3Ff2a74B66414fF35657Fa0E2"
+    tokenSafeContractAddress: "0xc4A29a94f12be03033daa4e6Ce9b9678c26275a2"
+    previousCashierContractAddress: "0x124B468860ac994ef28D11643d16e88dd4F26085"
+    validatorContractAddress: "0x87E2D48De6CC2029fFc1a915462e4Aa597890cd6"
+    startBlockHeight: 48300000
+    transferTableName: "iotex_to_matic_transfers"
+    tokenPairs:
+      # WMATIC
+      - token1: "io13envp44hps9j85ulfvs6r6k99wagaky60pzl2c"
+        token2: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
+      # WETH
+      - token1: "io1v5m9d7zrs852xkdzdresqf3phwc5cchc5crylc"
+        token2: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+      # WBTC
+      - token1: "io10u9dv0ys93nmr7smzyptpkhlhzylt4wtqzrvld"
+        token2: "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
+      # DAI
+      - token1: "io1v25anp7t7nz954gdam2m27eqp4arr93jly4maa"
+        token2: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+      # USDT
+      - token1: "io18ndhcj88pwz5a5h68yhzz6r4q8vykwhugq45ns"
+        token2: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+      # USDC
+      - token1: "io1cpx682vazuf4s4amjd7jlwejr5akc65plgmdru"
+        token2: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+      # SUSHI
+      - token1: "io1990thrrc9cvxhjmsmx5pysznqs734h6uhxfxkq"
+        token2: "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a"
+      # QUICK
+      - token1: "io1u346nz58mj5cjuj7ng3cn96upwam37v9axtju2"
+        token2: "0x831753DD7087CaC61aB5644b308642cc1c33Dc13"
+      # AAVE
+      - token1: "io14tw8gyn3p8v5fcmvh4c0w8797ryjrlrvnsr6zf"
+        token2: "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
+      # CYC
+      - token1: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
+        token2: "0xcFb54a6D2dA14ABeCD231174FC5735B4436965D8"
+      # CIOTX
 #       - token1: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
 #         token2: "0x300211Def2a644b036A9bdd3e58159bb2074d388"
-#       # SHIBX
+      # SHIBX
 #       - token1: "io1g29kuat5d727cqcjv5ta8607ys9kdp5fx702ua"
 #         token2: "0xe04E81331bDcBfBF2D1342714812d546a55CB6DC"
-#       # GEOD
-#       - token1: "io13cej9ysx7unfj0j200ma5g687d6rh795rk3v3n"
-#         token2: "0xf53224ec685b674eb4f5c365d30876efb05fbfe5"
-#       # DIMO
-#       - token1: "io1v8dekzzrymfz28xtqffvrr7ekr5g0jj0fcz5ea"
-#         token2: "0x7c09a86b761bfd9d996fe0d7ff8390c4ee7b3aec"
-#       # XNET
+      # GEOD
+      - token1: "io13cej9ysx7unfj0j200ma5g687d6rh795rk3v3n"
+        token2: "0xf53224ec685b674eb4f5c365d30876efb05fbfe5"
+      # DIMO
+      - token1: "io1v8dekzzrymfz28xtqffvrr7ekr5g0jj0fcz5ea"
+        token2: "0x7c09a86b761bfd9d996fe0d7ff8390c4ee7b3aec"
+      # XNET
 #       - token1: "io12t04n0staz4a4wafuwrzerq0r79nl6w2cphpeh"
 #         token2: "0x1524b9de9aa259633a2e1dad37476f24898e3aaa"
-#       # WNT
+      # WNT
 #       - token1: "io12falqd0u5fje0jtx23n535egfzkl2gtwes6r58"
 #         token2: "0xFBcAA472E25994E96889ae33C1b185DaD7bFf3Ef"
-#       # WIFI
+      # WIFI
 #       - token1: "io1em553udth5j85hjp4z9j3xgdhq00qz7uq5egha"
 #         token2: "0x8F26b442B6681567f6EaA75828140712f939Fb9e"
-#       # DATA
+      # DATA
 #       - token1: "io1rt3y6jfg4ph64txhrn6pf54n5jv6mv5mjlp37u"
 #         token2: "0x72F30B99C6bc3681508950b47A50fe0b18eF4BE6"
-#       # MYST
+      # MYST
 #       - token1: "io1t6ujp39vhku3adg3uxajjvcgyu5h36q8yfsurk"
 #         token2: "0x9D06d28aDaC1d9843034c61EE22991469413d790"
-#       # ECLD
+      # ECLD
 #       - token1: "io15ceyyccy8cwz5cx3vwdteckk3tzy2y2l9802y0"
 #         token2: "0x85D62B139464aaFEA83EdF790D2e723560b837bb"

--- a/witness-config-matic-payload.yaml
+++ b/witness-config-matic-payload.yaml
@@ -11,7 +11,7 @@ cashiers:
   - id: "matic-to-iotex-payload"
     withPayload: true
     relayerURL: ":7201"
-    startBlockHeight: 63196610
+    startBlockHeight: 87000000
     cashierContractAddress: "0x990B503f8C7353f1caB6f9D5bbF8f0Be2718D731"
     tokenSafeContractAddress: "0xA239F03Cda98A7d2AaAA51e7bF408e5d73399e45"
     validatorContractAddress: "0x915241176a644A29F46F5F4F8Bd49309e461a9bD"
@@ -37,10 +37,12 @@ cashiers:
         token1: "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
       - token2: "io1f4acssp65t6s90egjkzpvrdsrjjyysnvxgqjrh"
         token1: "0xcFb54a6D2dA14ABeCD231174FC5735B4436965D8"
-      - token2: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
-        token1: "0x300211Def2a644b036A9bdd3e58159bb2074d388"
-      - token2: "io1g29kuat5d727cqcjv5ta8607ys9kdp5fx702ua"
-        token1: "0xe04E81331bDcBfBF2D1342714812d546a55CB6DC"
+      # CIOTX
+#      - token2: "io1nxetpma4de3wx6tqcgxdtj5wc64a24t64dc76s"
+#        token1: "0x300211Def2a644b036A9bdd3e58159bb2074d388"
+      # SHIBX
+#      - token2: "io1g29kuat5d727cqcjv5ta8607ys9kdp5fx702ua"
+#        token1: "0xe04E81331bDcBfBF2D1342714812d546a55CB6DC"
       # GEOD
       - token2: "io13cej9ysx7unfj0j200ma5g687d6rh795rk3v3n"
         token1: "0xf53224ec685b674eb4f5c365d30876efb05fbfe5"
@@ -48,20 +50,20 @@ cashiers:
       - token2: "io1v8dekzzrymfz28xtqffvrr7ekr5g0jj0fcz5ea"
         token1: "0x7c09a86b761bfd9d996fe0d7ff8390c4ee7b3aec"
       # XNET
-      - token2: "io12t04n0staz4a4wafuwrzerq0r79nl6w2cphpeh"
-        token1: "0x1524b9de9aa259633a2e1dad37476f24898e3aaa"
+#      - token2: "io12t04n0staz4a4wafuwrzerq0r79nl6w2cphpeh"
+#        token1: "0x1524b9de9aa259633a2e1dad37476f24898e3aaa"
       # WNT
-      - token2: "io12falqd0u5fje0jtx23n535egfzkl2gtwes6r58"
-        token1: "0xFBcAA472E25994E96889ae33C1b185DaD7bFf3Ef"
+#      - token2: "io12falqd0u5fje0jtx23n535egfzkl2gtwes6r58"
+#        token1: "0xFBcAA472E25994E96889ae33C1b185DaD7bFf3Ef"
       # WIFI
-      - token2: "io1em553udth5j85hjp4z9j3xgdhq00qz7uq5egha"
-        token1: "0x8F26b442B6681567f6EaA75828140712f939Fb9e"
+#      - token2: "io1em553udth5j85hjp4z9j3xgdhq00qz7uq5egha"
+#        token1: "0x8F26b442B6681567f6EaA75828140712f939Fb9e"
       # DATA
-      - token2: "io1rt3y6jfg4ph64txhrn6pf54n5jv6mv5mjlp37u"
-        token1: "0x72F30B99C6bc3681508950b47A50fe0b18eF4BE6"
+#      - token2: "io1rt3y6jfg4ph64txhrn6pf54n5jv6mv5mjlp37u"
+#        token1: "0x72F30B99C6bc3681508950b47A50fe0b18eF4BE6"
       # MYST
-      - token2: "io1t6ujp39vhku3adg3uxajjvcgyu5h36q8yfsurk"
-        token1: "0x9D06d28aDaC1d9843034c61EE22991469413d790"
+#      - token2: "io1t6ujp39vhku3adg3uxajjvcgyu5h36q8yfsurk"
+#        token1: "0x9D06d28aDaC1d9843034c61EE22991469413d790"
       # ECLD
-      - token2: "io15ceyyccy8cwz5cx3vwdteckk3tzy2y2l9802y0"
-        token1: "0x85D62B139464aaFEA83EdF790D2e723560b837bb"
+#      - token2: "io15ceyyccy8cwz5cx3vwdteckk3tzy2y2l9802y0"
+#        token1: "0x85D62B139464aaFEA83EdF790D2e723560b837bb"


### PR DESCRIPTION
## Changes

**BSC (`bsc-payload` bsc→iotex, `iotex-payload` iotex→bsc)** — enable 5 pairs each direction:
WBNB, CYC, BSC-USD, USDC, XPIN.

**Polygon (`iotex-payload` iotex→matic, `matic-payload` matic→iotex)** — enable 12 pairs each direction:
WMATIC, WETH, WBTC, DAI, USDT, USDC, SUSHI, QUICK, AAVE, CYC, GEOD, DIMO.

**startBlockHeight**
| cashier | value |
|---|---|
| iotex→bsc | 48300000 |
| bsc→iotex | 99705816 |
| iotex→matic | 48300000 |
| matic→iotex | 87000000 |

**Still commented out** (unchanged behaviour): CIOTX and BUSD on all directions; on `matic` also SHIBX, XNET, WNT, WIFI, DATA, MYST, ECLD; the `iotex→ethereum` cashier stays fully disabled.

**ethereum-payload**: comment out CIOTX (eth→iotex).