### PR TITLE
fix: strip inline DB password from public relayer/witness configs

### DIFF
--- a/relayer-config-bsc-payload.yaml
+++ b/relayer-config-bsc-payload.yaml
@@ -27,7 +27,7 @@ unwrappers:
 #     # NB
 #     0xD0781be7335ec2C820bD3F9687dDe809892d985e: "0xc2bD425A63800731E3Ae42b6596BDD783299fCb1"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "bsc_transfers"
 witnessTableName: "bsc_witnesses"

--- a/relayer-config-bsc-payload.yaml
+++ b/relayer-config-bsc-payload.yaml
@@ -27,7 +27,7 @@ unwrappers:
 #     # NB
 #     0xD0781be7335ec2C820bD3F9687dDe809892d985e: "0xc2bD425A63800731E3Ae42b6596BDD783299fCb1"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "bsc_transfers"
 witnessTableName: "bsc_witnesses"

--- a/relayer-config-bsc-testnet.yaml
+++ b/relayer-config-bsc-testnet.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "0x5E0Eba3f0c9e047BbcD88441865F97643ab97Fd3"
 database:
-  uri: "root:@tcp(localhost:13306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "bsc_testnet_transfers"
 witnessTableName: "bsc_testnet_witnesses"

--- a/relayer-config-bsc-testnet.yaml
+++ b/relayer-config-bsc-testnet.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "0x5E0Eba3f0c9e047BbcD88441865F97643ab97Fd3"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/relayer?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "bsc_testnet_transfers"
 witnessTableName: "bsc_testnet_witnesses"

--- a/relayer-config-ethereum-payload.yaml
+++ b/relayer-config-ethereum-payload.yaml
@@ -41,7 +41,7 @@ unwrappers:
     # WETH -> ETH
     0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2: "0x0000000000000000000000000000000000000000"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "ethereum_transfers"
 witnessTableName: "ethereum_witnesses"

--- a/relayer-config-ethereum-payload.yaml
+++ b/relayer-config-ethereum-payload.yaml
@@ -41,7 +41,7 @@ unwrappers:
     # WETH -> ETH
     0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2: "0x0000000000000000000000000000000000000000"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "ethereum_transfers"
 witnessTableName: "ethereum_witnesses"

--- a/relayer-config-heco.yaml
+++ b/relayer-config-heco.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "io1s6m6j3cdj0j7hlgupx0pww7wscvkepdjfwgkra"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "heco_transfers"
 witnessTableName: "heco_witnesses"

--- a/relayer-config-heco.yaml
+++ b/relayer-config-heco.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "io1s6m6j3cdj0j7hlgupx0pww7wscvkepdjfwgkra"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "heco_transfers"
 witnessTableName: "heco_witnesses"

--- a/relayer-config-iotex-payload.yaml
+++ b/relayer-config-iotex-payload.yaml
@@ -32,7 +32,7 @@ unwrappers:
 #     # old DATA -> new DATA
 #     0x1ae24d4928a86faaacd71cf414d2b3a499adb29b: "0xD94be6fd546d4cE502CB1E870A58330Cc8869e9B"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "iotex_transfers"
 witnessTableName: "iotex_witnesses"

--- a/relayer-config-iotex-payload.yaml
+++ b/relayer-config-iotex-payload.yaml
@@ -32,7 +32,7 @@ unwrappers:
 #     # old DATA -> new DATA
 #     0x1ae24d4928a86faaacd71cf414d2b3a499adb29b: "0xD94be6fd546d4cE502CB1E870A58330Cc8869e9B"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "iotex_transfers"
 witnessTableName: "iotex_witnesses"

--- a/relayer-config-iotex-testnet.yaml
+++ b/relayer-config-iotex-testnet.yaml
@@ -15,7 +15,7 @@ validators:
     cashiers:
       - address: "0xBAe51dAad36A1fEA46492F35E04380B3db169A97"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/relayer?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "iotex_testnet_transfers"
 witnessTableName: "iotex_testnet_witnesses"

--- a/relayer-config-iotex-testnet.yaml
+++ b/relayer-config-iotex-testnet.yaml
@@ -15,7 +15,7 @@ validators:
     cashiers:
       - address: "0xBAe51dAad36A1fEA46492F35E04380B3db169A97"
 database:
-  uri: "root:@tcp(localhost:13306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "iotex_testnet_transfers"
 witnessTableName: "iotex_testnet_witnesses"

--- a/relayer-config-matic-payload.yaml
+++ b/relayer-config-matic-payload.yaml
@@ -32,7 +32,7 @@ unwrappers:
     # ECLD
     0x85D62B139464aaFEA83EdF790D2e723560b837bb: "0xc6920888988cAcEeA7ACCA0c96f2D65b05eE22Ba"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "matic_transfers"
 witnessTableName: "matic_witnesses"

--- a/relayer-config-matic-payload.yaml
+++ b/relayer-config-matic-payload.yaml
@@ -32,7 +32,7 @@ unwrappers:
     # ECLD
     0x85D62B139464aaFEA83EdF790D2e723560b837bb: "0xc6920888988cAcEeA7ACCA0c96f2D65b05eE22Ba"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "matic_transfers"
 witnessTableName: "matic_witnesses"

--- a/relayer-config-polis.yaml
+++ b/relayer-config-polis.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "io1aw89kuzrlyekzvwqyw3e82c880qaxwup5hv7ee"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "polis_transfers"
 witnessTableName: "polis_witnesses"

--- a/relayer-config-polis.yaml
+++ b/relayer-config-polis.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "io1aw89kuzrlyekzvwqyw3e82c880qaxwup5hv7ee"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "polis_transfers"
 witnessTableName: "polis_witnesses"

--- a/relayer-config-sepolia.yaml
+++ b/relayer-config-sepolia.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "0xe17f31649C42CE0304008C81Fb7A912cE4e82380"
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "sepolia_transfers"
 witnessTableName: "sepolia_witnesses"

--- a/relayer-config-sepolia.yaml
+++ b/relayer-config-sepolia.yaml
@@ -12,7 +12,7 @@ validators:
     cashiers:
       - address: "0xe17f31649C42CE0304008C81Fb7A912cE4e82380"
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "sepolia_transfers"
 witnessTableName: "sepolia_witnesses"

--- a/relayer-config-solana.yaml
+++ b/relayer-config-solana.yaml
@@ -6,7 +6,7 @@ grpcProxyPort: 8007
 privateKey: ""
 slackWebHook: "" 
 database:
-  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "solana_transfers"
 witnessTableName: "solana_witnesses"

--- a/relayer-config-solana.yaml
+++ b/relayer-config-solana.yaml
@@ -6,7 +6,7 @@ grpcProxyPort: 8007
 privateKey: ""
 slackWebHook: "" 
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(database:3306)/relayer?parseTime=true"
+  uri: "root:@tcp(database:3306)/relayer?parseTime=true"
   driver: "mysql"
 transferTableName: "solana_transfers"
 witnessTableName: "solana_witnesses"

--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9287
 interval: 10s
 batchSize: 10
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "bsc-to-iotex-payload"

--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9287
 interval: 10s
 batchSize: 10
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "bsc-to-iotex-payload"

--- a/witness-config-bsc-testnet.yaml
+++ b/witness-config-bsc-testnet.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9185
 interval: 15s
 batchSize: 500
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "bsc-testnet-to-iotex-testnet"

--- a/witness-config-bsc-testnet.yaml
+++ b/witness-config-bsc-testnet.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9185
 interval: 15s
 batchSize: 500
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "bsc-testnet-to-iotex-testnet"

--- a/witness-config-ethereum-payload.yaml
+++ b/witness-config-ethereum-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9283
 interval: 1m
 batchSize: 40
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "ethereum-to-iotex-payload"

--- a/witness-config-ethereum-payload.yaml
+++ b/witness-config-ethereum-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9283
 interval: 1m
 batchSize: 40
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "ethereum-to-iotex-payload"

--- a/witness-config-iotex-payload.yaml
+++ b/witness-config-iotex-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9281
 interval: 1m
 batchSize: 1000
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
 #   - id: "iotex-to-ethereum-payload"

--- a/witness-config-iotex-payload.yaml
+++ b/witness-config-iotex-payload.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9281
 interval: 1m
 batchSize: 1000
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
 #   - id: "iotex-to-ethereum-payload"

--- a/witness-config-iotex-solana.yaml
+++ b/witness-config-iotex-solana.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9321
 interval: 30s
 batchSize: 1000
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "iotex-to-solana"

--- a/witness-config-iotex-solana.yaml
+++ b/witness-config-iotex-solana.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9321
 interval: 30s
 batchSize: 1000
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "iotex-to-solana"

--- a/witness-config-iotex-testnet.yaml
+++ b/witness-config-iotex-testnet.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9181
 interval: 10s
 batchSize: 1000
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "iotex-testnet-to-bsc-testnet"

--- a/witness-config-iotex-testnet.yaml
+++ b/witness-config-iotex-testnet.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9181
 interval: 10s
 batchSize: 1000
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "iotex-testnet-to-bsc-testnet"

--- a/witness-config-matic-payload.yaml
+++ b/witness-config-matic-payload.yaml
@@ -5,7 +5,7 @@ interval: 20s
 batchSize: 100
 confirmBlockNumber: 255
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "matic-to-iotex-payload"

--- a/witness-config-matic-payload.yaml
+++ b/witness-config-matic-payload.yaml
@@ -5,7 +5,7 @@ interval: 20s
 batchSize: 100
 confirmBlockNumber: 255
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "matic-to-iotex-payload"

--- a/witness-config-sepolia.yaml
+++ b/witness-config-sepolia.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9183
 interval: 15s
 batchSize: 500
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "sepolia-to-iotex-testnet"

--- a/witness-config-sepolia.yaml
+++ b/witness-config-sepolia.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9183
 interval: 15s
 batchSize: 500
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "sepolia-to-iotex-testnet"

--- a/witness-config-solana.yaml
+++ b/witness-config-solana.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9121
 interval: 1m
 batchSize: 150
 database:
-  uri: "root:kdfjjrU64fjK58H@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "solana-to-iotex"

--- a/witness-config-solana.yaml
+++ b/witness-config-solana.yaml
@@ -4,7 +4,7 @@ grpcProxyPort: 9121
 interval: 1m
 batchSize: 150
 database:
-  uri: "root:@tcp(localhost:13306)/witness?parseTime=true"
+  uri: "root:${DB_ROOT_PASSWORD}@tcp(localhost:13306)/witness?parseTime=true"
   driver: "mysql"
 cashiers:
   - id: "solana-to-iotex"


### PR DESCRIPTION
## What

`database.uri` in the **19 public** relayer/witness config files no longer carries an inline password. It now references the `${DB_ROOT_PASSWORD}` environment variable, which the witness/relayer binaries expand at load time (both load config with `config.Expand(os.LookupEnv)`).

```
- uri: "root:<inline-password>@tcp(database:3306)/relayer?parseTime=true"
+ uri: "root:${DB_ROOT_PASSWORD}@tcp(database:3306)/relayer?parseTime=true"
```

The DB user (`root`), host, port, database name, and `parseTime` are unchanged. **The env var name `DB_ROOT_PASSWORD` is the same one hosts already set** (it initializes the local MySQL container), so no `.env` needs renaming.

### Why
- The credential is no longer stored in the public config.
- Single source of truth per host: the value that initializes the MySQL container (`MYSQL_ROOT_PASSWORD`) now also supplies the app connection string.

## Operator action
- Companion PR `iotubeproject/ioTube#325` updates the compose templates to pass `DB_ROOT_PASSWORD` into each witness/relayer service environment. Deploying both together requires no `.env` change.
- Running hosts are unaffected until they next copy these configs (via `start_*.sh`), which also copies the updated compose.
