### PR TITLE
config: enable finalized BSC confirmations

### DIFF
--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -1,4 +1,6 @@
 chain: "bsc"
+confirmBlockNumber: 20
+useFinalizedBlock: true
 grpcPort: 9286
 grpcProxyPort: 9287
 interval: 10s

--- a/witness-config-bsc-payload.yaml
+++ b/witness-config-bsc-payload.yaml
@@ -1,5 +1,5 @@
 chain: "bsc"
-confirmBlockNumber: 20
+confirmBlockNumber: 50
 useFinalizedBlock: true
 grpcPort: 9286
 grpcProxyPort: 9287


### PR DESCRIPTION
## Summary

- Enable finalized block tracking for BSC witnesses.
- Retain a 50-block margin behind the finalized tip (defense in depth; BSC `finalized` is already BEP-126 BFT-final, the margin covers a finality-gadget failure). Matches the value recorded in iotube-ops.

## Validation

- Parsed by the witness configuration regression test in ioTube.
- BSC RPC finalized-tag support was verified separately.

## Rollout note

Takes effect only on witnesses running the ioTube binary with #326/#329; older binaries ignore `useFinalizedBlock` (and 50 only affects the fallback depth). Needs ≥2/4 witnesses for the 3-of-4 protection to bind. First enable on a busy route may fail-fast for manual review by design (#329).